### PR TITLE
debian-dsc.bbclass: Remove epoch when get PV

### DIFF
--- a/classes/debian-dsc.bbclass
+++ b/classes/debian-dsc.bbclass
@@ -3,6 +3,8 @@
 # Copyright (C) 2018 Alexander Smirnov
 
 python __anonymous() {
+    import re
+
     # Parse DSC_URI and its checksums
     dsc_uri = (d.getVar("DSC_URI", True) or "").split()
     if len(dsc_uri) == 0:
@@ -34,6 +36,8 @@ python __anonymous() {
             # Get package version and export PV
             if line.startswith('Version:'):
                 pv = line.split(": ")[-1].rstrip()
+                # Remove epoch
+                pv = re.sub(r'^\S*:', '', pv)
                 d.setVar('PV', pv)
             elif line.startswith('Files:'):
                 line = file.readline()

--- a/classes/debian-dsc.bbclass
+++ b/classes/debian-dsc.bbclass
@@ -42,8 +42,9 @@ python __anonymous() {
             elif line.startswith('Files:'):
                 line = file.readline()
                 while line and line.startswith(' '):
+                    md5sum = line.split()[0]
                     f = line.split()[2]
-                    files.append(repo + f)
+                    files.append(repo + f + ";md5sum=" + md5sum)
                     line = file.readline()
                 break
             line = file.readline()


### PR DESCRIPTION
Set PV with epoch can cause wrong .dsc file name.

For example: vim has .dsc is vim_8.1.0875-2.dsc, but the PV
with epoch is 2:8.1.0875-2.

Signed-off-by: Trung Do <trung.dothanh@toshiba-tsdv.com>